### PR TITLE
Add functionality for saving the results of games

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,7 @@ venv.bak/
 
 # Pycharm settings
 .idea
+
+# --- Project specific settings ---
+# Directory for storing saved games
+data/

--- a/modules/statistics.py
+++ b/modules/statistics.py
@@ -7,10 +7,25 @@ for the analyzis of this data, such as the scoreboard, player rankings and so
 on.
 """
 
+import pickle
 from pathlib import Path
+from typing import List, Optional
 
 
 DEFAULT_SAVE_PATH = Path(__file__).parents[1] / 'data' / 'savefile'
+
+
+class Data:
+    """Class responsible for storing data related to the statistics module."""
+
+    def __init__(self):
+        """
+        Construct Data object.
+
+        No parameters are accepted, as the class is intended to be instantiated
+        with no data and then mutated with new data that may come in.
+        """
+        self.all_rankings = []
 
 
 class Statistics:
@@ -21,30 +36,51 @@ class Statistics:
     API.
     """
 
-    def __init__(self, save_path: Path = DEFAULT_SAVE_PATH) -> bool:
+    def __init__(self, save_path: Path = DEFAULT_SAVE_PATH) -> None:
         """
         Construct statistics object from save file stored on disk.
 
         :param save_path: Path to file that contains saved games.
         """
+        assert isinstance(save_path, Path)
         self.save_path = save_path
-        self.load_save_file(save_path)
+        self.load_data()
 
-    @staticmethod
-    def load_save_file(path: Path) -> bool:
+    def save(self, ranking: Optional[List[str]] = None) -> None:
+        """
+        Save new data from a game for later retrieval and analysis.
+
+        :param ranking: A list of strings ordered by whom did best during the
+          game in descending order.
+          For instance ranking=['gold', 'silver', 'bronze'].
+        """
+        if ranking:
+            assert isinstance(ranking, list)
+            assert isinstance(ranking[0], str)
+            self.data.all_rankings.append(ranking)
+        self.save_data()
+
+    def load_data(self) -> None:
         """
         Load the save data stored in the given path.
 
         If the path does not exist, the save file is created.
+        The data is persisted to self.data.
 
         :param path: Absolute path to savefile.
-        :return: Returns True if the savefile already exists, False otherwise.
         """
-        assert path.is_absolute()
-        path.parent.mkdir(parents=True, exist_ok=True)
+        assert self.save_path.is_absolute()
+        self.save_path.parent.mkdir(parents=True, exist_ok=True)
 
-        if not path.exists():
-            path.touch()
-            return False
+        if not self.save_path.exists():
+            self.save_path.touch()
+            self.data = Data()
+            self.save_data()
         else:
-            return True
+            self.data = pickle.loads(self.save_path.read_bytes())
+
+    def save_data(self) -> None:
+        """Save data to path specified by __init__ save_path parameter."""
+        self.save_path.write_bytes(
+            data=pickle.dumps(self.data, protocol=pickle.HIGHEST_PROTOCOL),
+        )

--- a/modules/statistics.py
+++ b/modules/statistics.py
@@ -1,0 +1,50 @@
+"""
+Module responsible for the storage and retrieval of statistics.
+
+In practice, this means that this module is able to save the results of earlier
+games to disk and retrieve these results at a later time. It is also responsible
+for the analyzis of this data, such as the scoreboard, player rankings and so
+on.
+"""
+
+from pathlib import Path
+
+
+DEFAULT_SAVE_PATH = Path(__file__).parents[1] / 'data' / 'savefile'
+
+
+class Statistics:
+    """
+    Class for saving and retrieval of statistics.
+
+    This is the main class of this module, and this is considered the public
+    API.
+    """
+
+    def __init__(self, save_path: Path = DEFAULT_SAVE_PATH) -> bool:
+        """
+        Construct statistics object from save file stored on disk.
+
+        :param save_path: Path to file that contains saved games.
+        """
+        self.save_path = save_path
+        self.load_save_file(save_path)
+
+    @staticmethod
+    def load_save_file(path: Path) -> bool:
+        """
+        Load the save data stored in the given path.
+
+        If the path does not exist, the save file is created.
+
+        :param path: Absolute path to savefile.
+        :return: Returns True if the savefile already exists, False otherwise.
+        """
+        assert path.is_absolute()
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        if not path.exists():
+            path.touch()
+            return False
+        else:
+            return True

--- a/modules/statistics.py
+++ b/modules/statistics.py
@@ -44,7 +44,7 @@ class Statistics:
         """
         assert isinstance(save_path, Path)
         self.save_path = save_path
-        self.load_data()
+        self._load_data()
 
     def save(self, ranking: Optional[List[str]] = None) -> None:
         """
@@ -58,9 +58,9 @@ class Statistics:
             assert isinstance(ranking, list)
             assert isinstance(ranking[0], str)
             self.data.all_rankings.append(ranking)
-        self.save_data()
+        self._save_data()
 
-    def load_data(self) -> None:
+    def _load_data(self) -> None:
         """
         Load the save data stored in the given path.
 
@@ -75,11 +75,11 @@ class Statistics:
         if not self.save_path.exists():
             self.save_path.touch()
             self.data = Data()
-            self.save_data()
+            self._save_data()
         else:
             self.data = pickle.loads(self.save_path.read_bytes())
 
-    def save_data(self) -> None:
+    def _save_data(self) -> None:
         """Save data to path specified by __init__ save_path parameter."""
         self.save_path.write_bytes(
             data=pickle.dumps(self.data, protocol=pickle.HIGHEST_PROTOCOL),

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -1,9 +1,18 @@
 from pathlib import Path
 
+import pytest
+
 from modules.statistics import Statistics
 
-def test_creation_of_save_file():
+
+@pytest.fixture
+def save_path(tmpdir):
+    """Return a temporary save file path."""
+    return Path(tmpdir) / 'savefile'
+
+
+def test_creation_of_save_file(save_path):
     """Statistics object should automatically create save file."""
-    stats = Statistics()
+    stats = Statistics(save_path = save_path)
     save_path = stats.save_path
     assert save_path.exists()

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -11,8 +11,36 @@ def save_path(tmpdir):
     return Path(tmpdir) / 'savefile'
 
 
+@pytest.fixture
+def stats(save_path):
+    """Return a statistics object which will be recycled after the test."""
+    return Statistics(save_path=save_path)
+
+
 def test_creation_of_save_file(save_path):
     """Statistics object should automatically create save file."""
-    stats = Statistics(save_path = save_path)
+    stats = Statistics(save_path=save_path)
     save_path = stats.save_path
     assert save_path.exists()
+
+
+def test_saving_the_winner_of_a_game(save_path):
+    """Test the saving and retrieval of game rankings."""
+    # First, create a completely new statistics object
+    stats = Statistics(save_path=save_path)
+
+    # Save the results of two consecutive games
+    stats.save(ranking=['gold1', 'bronze1', 'silver1', 'loser1'])
+    stats.save(ranking=['gold2', 'bronze2', 'silver2', 'loser2'])
+
+    # Check if the results are immediatly retrievable
+    expected_rankings = [
+        ['gold1', 'bronze1', 'silver1', 'loser1'],
+        ['gold2', 'bronze2', 'silver2', 'loser2']
+    ]
+    assert stats.data.all_rankings == expected_rankings
+
+    # And then check if the same data can be retrieved after a "restart"
+    del stats
+    new_stats = Statistics(save_path=save_path)
+    assert new_stats.data.all_rankings == expected_rankings

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+from modules.statistics import Statistics
+
+def test_creation_of_save_file():
+    """Statistics object should automatically create save file."""
+    stats = Statistics()
+    save_path = stats.save_path
+    assert save_path.exists()


### PR DESCRIPTION
# Add functionality for saving the results of games

## Description

This PR implements the ability to store information gathered during a game session.
It persists the data to the disk so it can be loaded after the game restarts.

## Example of use

Here is how you would save the fact that Yan won, Harald came on second place, while Kristoffer came in last:

```{python}
from modules.statistics import Statistics

stats = Statistics()
stats = stats.save(rankings=['Yan', 'Harald', 'Kristoffer'])
```

The results are now saved to disk and will be loaded the next time `Statistics()` is constructed.

## The way forward

* I will add more optional parameters to `stats.save()` if there is more data we would like to save. ~10 minutes of work for each parameter.
* Calculation of ELO for each player using [multi-elo](https://pypi.org/project/multi-elo/). ~ 1.5 hours of work.
* Make a public API for retrieving statistical analysis from this data. Before I do this, we should probably discuss the data format we want to pass to the rendering module. ~ 2 hours of work.